### PR TITLE
Enable multi-resource selection in Gantt toolbar

### DIFF
--- a/Portal/_Public/Gantt/paginas/detail/app.umd.js
+++ b/Portal/_Public/Gantt/paginas/detail/app.umd.js
@@ -9,7 +9,8 @@ var {
     TaskModel,
     Gantt,
     Grid,
-    Popup
+    Popup,
+    CheckColumn
 } = bryntum.gantt;
 
 
@@ -542,7 +543,10 @@ async function gerenciarRecursos() {
             data: recursos,
             height: 300,
             width: 400,
-            selectionMode: { mode: 'multi' }
+            selectionMode: {
+                checkbox: true,
+                multiSelect: true
+            }
         });
 
         const popup = new Popup({
@@ -557,6 +561,10 @@ async function gerenciarRecursos() {
                 text: 'Adicionar ao projeto',
                 onClick() {
                     const selecionados = grid.selectedRecords || [];
+                    if (!selecionados.length) {
+                        Toast.show('Selecione ao menos um recurso.');
+                        return;
+                    }
                     console.log('Recursos selecionados', selecionados);
                     // TODO: Implementar persistência dos recursos selecionados
                     popup.close();


### PR DESCRIPTION
## Summary
- allow selecting multiple resources via checkbox grid in resource manager popup
- validate selection and warn if no resources are picked
- import CheckColumn to support checkbox column

## Testing
- `node --check Portal/_Public/Gantt/paginas/detail/app.umd.js`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894cd7a0b6c8330bca8b864be27910d