### PR TITLE
Include project resources in Gantt dataset

### DIFF
--- a/Portal/ApiHandler/GanttHandler.ashx
+++ b/Portal/ApiHandler/GanttHandler.ashx
@@ -11,6 +11,7 @@ using Cdis.Brisk.DataTransfer.Gantt;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Data;
 
 
 public class GanttHandler : IHttpHandler
@@ -134,6 +135,24 @@ public class GanttHandler : IHttpHandler
     public void GetJsonProject(HttpContext context, int idProjeto, short numLinhaBase, bool isCarregarHtmlCaminhoCritico)
     {
         var ganttDataset = UowApplication.GetUowApplication<CronogramaGanttApplication>().GetGanttDatasetDataTransfer(idProjeto, numLinhaBase, typeof(Resources.traducao), isCarregarHtmlCaminhoCritico);
+
+        dados cDados = CdadosUtil.GetCdados(null);
+        int codigoEntidade = int.Parse(cDados.getInfoSistema("CodigoEntidade").ToString());
+        DataSet dsRecursos = cDados.getRecursosCorporativosProjeto(idProjeto.ToString(), codigoEntidade);
+        var recursos = new List<ResourceGanttDataTransfer>();
+        if (dsRecursos != null && dsRecursos.Tables.Count > 0)
+        {
+            recursos = dsRecursos.Tables[0].Rows.Cast<DataRow>()
+                .Select(r => new ResourceGanttDataTransfer
+                {
+                    id = int.Parse(r["CodigoRecursoCorporativo"].ToString()),
+                    name = r["NomeRecursoCorporativo"].ToString()
+                })
+                .ToList();
+        }
+        ganttDataset.resources = new ResourcesGanttDataTransfer { rows = recursos };
+        ganttDataset.assignments = new AssignmentsGanttDataTransfer { rows = new List<AssignmentGanttDataTransfer>() };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
         context.Response.Write(ganttDataset.ToJson());

--- a/src/Cdis.Brisk.DataTransfer/Cdis.Brisk.DataTransfer.csproj
+++ b/src/Cdis.Brisk.DataTransfer/Cdis.Brisk.DataTransfer.csproj
@@ -44,6 +44,10 @@
     <Compile Include="Gantt\DependencyGanttDataTransfer.cs" />
     <Compile Include="Cronograma\InfoEapDataTransfer.cs" />
     <Compile Include="Gantt\GanttSaveDataTransfer.cs" />
+    <Compile Include="Gantt\ResourceGanttDataTransfer.cs" />
+    <Compile Include="Gantt\ResourcesGanttDataTransfer.cs" />
+    <Compile Include="Gantt\AssignmentGanttDataTransfer.cs" />
+    <Compile Include="Gantt\AssignmentsGanttDataTransfer.cs" />
     <Compile Include="Gantt\PlanoAcao\TaskItemGanttPlanoAcaoDataTransfer.cs" />
     <Compile Include="Gantt\PlanoAcao\TasksGanttPlanoAcaoDataTransfer.cs" />
     <Compile Include="Gantt\ProjetoMeta\TaskItemGanttProjetoMetaDataTransfer.cs" />

--- a/src/Cdis.Brisk.DataTransfer/Gantt/AssignmentGanttDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/AssignmentGanttDataTransfer.cs
@@ -1,0 +1,9 @@
+namespace Cdis.Brisk.DataTransfer.Gantt
+{
+    public class AssignmentGanttDataTransfer
+    {
+        public int id { get; set; }
+        public int resource { get; set; }
+        public int @event { get; set; }
+    }
+}

--- a/src/Cdis.Brisk.DataTransfer/Gantt/AssignmentsGanttDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/AssignmentsGanttDataTransfer.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Cdis.Brisk.DataTransfer.Gantt
+{
+    public class AssignmentsGanttDataTransfer
+    {
+        public List<AssignmentGanttDataTransfer> rows { get; set; }
+    }
+}

--- a/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
@@ -6,5 +6,7 @@
         public ProjectGanttDataTransfer project { get; set; }
         public object tasks { get; set; }
         public DependenciesGanttDataTransfer dependencies { get; set; }
+        public ResourcesGanttDataTransfer resources { get; set; }
+        public AssignmentsGanttDataTransfer assignments { get; set; }
     }
 }

--- a/src/Cdis.Brisk.DataTransfer/Gantt/ResourceGanttDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/ResourceGanttDataTransfer.cs
@@ -1,0 +1,8 @@
+namespace Cdis.Brisk.DataTransfer.Gantt
+{
+    public class ResourceGanttDataTransfer
+    {
+        public int id { get; set; }
+        public string name { get; set; }
+    }
+}

--- a/src/Cdis.Brisk.DataTransfer/Gantt/ResourcesGanttDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/ResourcesGanttDataTransfer.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Cdis.Brisk.DataTransfer.Gantt
+{
+    public class ResourcesGanttDataTransfer
+    {
+        public List<ResourceGanttDataTransfer> rows { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Extend Gantt dataset with resources and assignments
- Provide classes to serialize resources and assignments
- Load project resources via getRecursosCorporativosProjeto in GanttHandler

## Testing
- `dotnet build PortalEstrategia2016.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894d3225b0c8330a5bfabb39a3bf532