### PR TITLE
Fix resource listing for Bryntum Gantt tasks

### DIFF
--- a/Portal/_Public/Gantt/paginas/detail/Default.aspx.cs
+++ b/Portal/_Public/Gantt/paginas/detail/Default.aspx.cs
@@ -91,7 +91,7 @@ public partial class Gantt_Default : BriskGanttPageBase
                     }
                 ).ToJson();
 
-        DataSet dsRecursos = CDados.getRecursosCorporativosDisponiveisProjeto(idProjeto.ToString(), UsuarioLogado.CodigoEntidade);
+        DataSet dsRecursos = CDados.getRecursosCorporativosProjeto(idProjeto.ToString(), UsuarioLogado.CodigoEntidade);
         jsonRecursosCorporativos = "[]";
         if (dsRecursos != null && dsRecursos.Tables.Count > 0)
         {


### PR DESCRIPTION
## Summary
- Load project resources instead of available resources in Gantt detail page

## Testing
- `dotnet build PortalEstrategia2016.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894ec1088608330bad59a3d419f57af