### PR TITLE
Fix resource listing for Bryntum Gantt tasks

### DIFF
--- a/Portal/_Public/Gantt/paginas/detail/Default.aspx
+++ b/Portal/_Public/Gantt/paginas/detail/Default.aspx
@@ -340,9 +340,18 @@
 
         <script src="../_shared/shared.umd.js"></script>
         <script src="app.umd.js"></script>
+        <script>
+            gantt.project.on('load', function () {
+                const recursos = (window.recursosCorporativos || []).map(r => ({
+                    id: r.CodigoRecursoCorporativo,
+                    name: r.NomeRecursoCorporativo
+                }));
+                gantt.project.resourceStore.data = recursos;
+            });
+        </script>
         <dxcp:ASPxCallback ID="callbackAtualizaTela" runat="server" ClientInstanceName="callbackAtualizaTela" OnCallback="callbackAtualizaTela_Callback">
             <ClientSideEvents EndCallback="function(s, e) {
-	             window.location.reload();
+                     window.location.reload();
             }" />
         </dxcp:ASPxCallback>
     </form>

--- a/Portal/_Public/Gantt/paginas/detail/Default.aspx.cs
+++ b/Portal/_Public/Gantt/paginas/detail/Default.aspx.cs
@@ -91,7 +91,7 @@ public partial class Gantt_Default : BriskGanttPageBase
                     }
                 ).ToJson();
 
-        DataSet dsRecursos = CDados.getRecursosCorporativosDisponiveisProjeto(idProjeto.ToString(), UsuarioLogado.CodigoEntidade);
+        DataSet dsRecursos = CDados.getRecursosCorporativosProjeto(idProjeto.ToString(), UsuarioLogado.CodigoEntidade);
         jsonRecursosCorporativos = "[]";
         if (dsRecursos != null && dsRecursos.Tables.Count > 0)
         {


### PR DESCRIPTION
## Summary
- Load project resources instead of available resources in Gantt detail page
- Populate task editor with project resource data after project load

## Testing
- `dotnet build PortalEstrategia2016.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894ec1088608330bad59a3d419f57af