### PR TITLE
Call insereRecursosCorporativos when adding resources

### DIFF
--- a/Portal/_Public/Gantt/paginas/detail/app.umd.js
+++ b/Portal/_Public/Gantt/paginas/detail/app.umd.js
@@ -565,8 +565,8 @@ async function gerenciarRecursos() {
                         Toast.show('Selecione ao menos um recurso.');
                         return;
                     }
-                    console.log('Recursos selecionados', selecionados);
-                    // TODO: Implementar persistência dos recursos selecionados
+                    const ids = selecionados.map(r => r.CodigoRecursoCorporativo);
+                    insereRecursosCorporativos(JSON.stringify(ids));
                     popup.close();
                 }
             }]


### PR DESCRIPTION
## Summary
- Trigger `insereRecursosCorporativos` with selected resource IDs when adding corporate resources

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test PortalEstrategia2016.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f730262483309c2a20afcfa47002