### PR TITLE
Undo edits when cancelling in Bryntum Gantt

### DIFF
--- a/Portal/_Public/Gantt/paginas/detail/app.umd.js
+++ b/Portal/_Public/Gantt/paginas/detail/app.umd.js
@@ -328,7 +328,8 @@ const gantt = new Gantt({
                     icon: 'b-fa b-fa-close',
                     tooltip: "Cancelar",
                     disabled: true,
-                    onClick() {
+                    async onClick() {
+                        await stm.undoAll();
                         toggleEdit(false);
                     }
                 }


### PR DESCRIPTION
## Summary
- Ensure CancelarAlteracoes button rolls back all unsaved changes using the state tracking manager

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952bf5fe5483309d7cc227ba94460a