### PR TITLE
Fix task hierarchy identification in Gantt data

### DIFF
--- a/src/Cdis.Brisk.Application/Applications/Cronograma/CronogramaGanttApplication.cs
+++ b/src/Cdis.Brisk.Application/Applications/Cronograma/CronogramaGanttApplication.cs
@@ -243,7 +243,7 @@ namespace Cdis.Brisk.Application.Applications.Cronograma
         {
             List<TaskGanttDataTransfer> listTaskGantt = new List<TaskGanttDataTransfer>();
 
-            foreach (var task in listTasks.Where(g => g.TarefaSuperior == null))
+            foreach (var task in listTasks.Where(g => string.IsNullOrEmpty(g.TarefaSuperior) || g.TarefaSuperior == g.CodigoRealTarefa))
             {
                 listTaskGantt.Add(MontarTaskGanttDataTransfer(task, listTasks, typeResourceTraducao, isCarregarHtmlCaminhoCritico));
             }


### PR DESCRIPTION
## Summary
- ensure Gantt tasks identify root tasks correctly so hierarchy and indentation display properly

## Testing
- `dotnet build src/Cdis.Brisk.Application/Cdis.Brisk.Application.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1a1f2ba88330afaa228514be521e