### PR TITLE
Fix task hierarchy identification in Gantt data

### DIFF
--- a/src/Cdis.Brisk.Application/Applications/Cronograma/CronogramaGanttApplication.cs
+++ b/src/Cdis.Brisk.Application/Applications/Cronograma/CronogramaGanttApplication.cs
@@ -243,7 +243,10 @@ namespace Cdis.Brisk.Application.Applications.Cronograma
         {
             List<TaskGanttDataTransfer> listTaskGantt = new List<TaskGanttDataTransfer>();
 
-            foreach (var task in listTasks.Where(g => g.TarefaSuperior == null))
+            foreach (var task in listTasks.Where(g => string.IsNullOrWhiteSpace(g.TarefaSuperior) ||
+                                                     string.Equals(g.TarefaSuperior.Trim(),
+                                                                   g.CodigoRealTarefa?.Trim(),
+                                                                   StringComparison.OrdinalIgnoreCase)))
             {
                 listTaskGantt.Add(MontarTaskGanttDataTransfer(task, listTasks, typeResourceTraducao, isCarregarHtmlCaminhoCritico));
             }
@@ -299,11 +302,12 @@ namespace Cdis.Brisk.Application.Applications.Cronograma
         /// </summary>        
         private List<TaskGanttDataTransfer> GetListTaskGanttDataTransfer(FGetCronogramaGanttProjetoDomain task, List<FGetCronogramaGanttProjetoDomain> listTasks, Type typeResourceTraducao, bool isCarregarHtmlCaminhoCritico)
         {
-            if (listTasks.Any(t => t.TarefaSuperior == task.CodigoRealTarefa))
+            var codigo = task.CodigoRealTarefa?.Trim();
+            if (listTasks.Any(t => string.Equals(t.TarefaSuperior?.Trim(), codigo, StringComparison.OrdinalIgnoreCase)))
             {
                 List<TaskGanttDataTransfer> listTaskGantt = new List<TaskGanttDataTransfer>();
 
-                foreach (var taskItem in listTasks.Where(g => g.TarefaSuperior == task.CodigoRealTarefa))
+                foreach (var taskItem in listTasks.Where(g => string.Equals(g.TarefaSuperior?.Trim(), codigo, StringComparison.OrdinalIgnoreCase)))
                 {
                     listTaskGantt.Add((MontarTaskGanttDataTransfer(taskItem, listTasks, typeResourceTraducao, isCarregarHtmlCaminhoCritico)));
                 }


### PR DESCRIPTION
## Summary
- ensure Gantt tasks identify root and child tasks correctly so hierarchy and indentation display properly

## Testing
- `apt-get update` *(fails: 403 repository not signed)*
- `dotnet build src/Cdis.Brisk.Application/Cdis.Brisk.Application.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1a1f2ba88330afaa228514be521e