### PR TITLE
Fix Gantt tasks dataset type to preserve tree structure

### DIFF
--- a/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
@@ -4,7 +4,7 @@
     {
         public bool success { get; set; }
         public ProjectGanttDataTransfer project { get; set; }
-        public object tasks { get; set; }
+        public TasksGanttDataTransfer tasks { get; set; }
         public DependenciesGanttDataTransfer dependencies { get; set; }
         public ResourcesGanttDataTransfer resources { get; set; }
         public AssignmentsGanttDataTransfer assignments { get; set; }


### PR DESCRIPTION
## Summary
- Strongly type tasks in Gantt dataset to ensure proper JSON payload

## Testing
- `dotnet build src/Cdis.Brisk.DataTransfer/Cdis.Brisk.DataTransfer.csproj` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a077284df0833094e14f52426b0f5f