### PR TITLE
Fix Gantt tasks dataset type to preserve tree structure

### DIFF
--- a/src/Cdis.Brisk.DataTransfer/Gantt/Balanceamento/TasksGanttBalanceamentoDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/Balanceamento/TasksGanttBalanceamentoDataTransfer.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Cdis.Brisk.DataTransfer.Gantt;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.Balanceamento
 {
-    public class TasksGanttBalanceamentoDataTransfer
+    public class TasksGanttBalanceamentoDataTransfer : TasksGanttDataTransfer
     {
-        public List<TaskItemGanttBalanceamentoDataTransfer> rows { get; set; }
+        public new List<TaskItemGanttBalanceamentoDataTransfer> rows { get; set; }
     }
 }
+

--- a/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
@@ -4,7 +4,7 @@
     {
         public bool success { get; set; }
         public ProjectGanttDataTransfer project { get; set; }
-        public object tasks { get; set; }
+        public TasksGanttDataTransfer tasks { get; set; }
         public DependenciesGanttDataTransfer dependencies { get; set; }
         public ResourcesGanttDataTransfer resources { get; set; }
         public AssignmentsGanttDataTransfer assignments { get; set; }

--- a/src/Cdis.Brisk.DataTransfer/Gantt/PlanoAcao/TasksGanttPlanoAcaoDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/PlanoAcao/TasksGanttPlanoAcaoDataTransfer.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Cdis.Brisk.DataTransfer.Gantt;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.PlanoAcao
 {
-    public class TasksGanttPlanoAcaoDataTransfer
+    public class TasksGanttPlanoAcaoDataTransfer : TasksGanttDataTransfer
     {
-        public List<TaskItemGanttPlanoAcaoDataTransfer> rows { get; set; }
+        public new List<TaskItemGanttPlanoAcaoDataTransfer> rows { get; set; }
     }
 }
+

--- a/src/Cdis.Brisk.DataTransfer/Gantt/ProjetoMeta/TasksGanttProjetoMetaDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/ProjetoMeta/TasksGanttProjetoMetaDataTransfer.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Cdis.Brisk.DataTransfer.Gantt;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.ProjetoMeta
 {
-    public class TasksGanttProjetoMetaDataTransfer
+    public class TasksGanttProjetoMetaDataTransfer : TasksGanttDataTransfer
     {
-        public List<TaskItemGanttProjetoMetaDataTransfer> rows { get; set; }
+        public new List<TaskItemGanttProjetoMetaDataTransfer> rows { get; set; }
     }
 }
+


### PR DESCRIPTION
## Summary
- Strongly type tasks in Gantt dataset to ensure proper JSON payload
- Make specialized task collections derive from base `TasksGanttDataTransfer`

## Testing
- `dotnet build src/Cdis.Brisk.DataTransfer/Cdis.Brisk.DataTransfer.csproj` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a077284df0833094e14f52426b0f5f