### PR TITLE
Ensure Gantt dataset uses tasks rows structure

### DIFF
--- a/Portal/ApiHandler/GanttBalanceamentoHandler.ashx
+++ b/Portal/ApiHandler/GanttBalanceamentoHandler.ashx
@@ -50,9 +50,20 @@ public class GanttBalanceamentoHandler : IHttpHandler
     public void GetJsonProject(HttpContext context,int codEntidade,int codPortfolio,int numCenario)
     {
         var ganttDataset = UowApplication.GetUowApplication<CronogramaGanttBalanceamentoApplication>().GetGanttDatasetDataTransfer(codEntidade, codPortfolio, numCenario, typeof(Resources.traducao));
+
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = new { rows = ganttDataset.tasks?.rows },
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable {

--- a/Portal/ApiHandler/GanttHandler.ashx
+++ b/Portal/ApiHandler/GanttHandler.ashx
@@ -173,9 +173,19 @@ public class GanttHandler : IHttpHandler
         ganttDataset.resources = new ResourcesGanttDataTransfer { rows = recursos };
         ganttDataset.assignments = new AssignmentsGanttDataTransfer { rows = atribuicoes };
 
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = new { rows = ganttDataset.tasks?.rows },
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable

--- a/Portal/ApiHandler/GanttPlanoAcaoHandler.ashx
+++ b/Portal/ApiHandler/GanttPlanoAcaoHandler.ashx
@@ -49,9 +49,19 @@ public class GanttPlanoAcaoHandler : IHttpHandler
                 ? UowApplication.GetUowApplication<CronogramaGanttPlanoAcaoApplication>().GetGanttDatasetDataTransfer(iniciaisObjeto, idObjeto, idEntidade, isIniciativas)
                 : UowApplication.GetUowApplication<CronogramaGanttPlanoAcaoApplication>().GetGanttPlanoAcaoDatasetDataTransfer(idPlanoAcao, iniciaisObjeto, idObjeto, idEntidade, isIniciativas);
 
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = new { rows = ganttDataset.tasks?.rows },
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable {

--- a/Portal/ApiHandler/GanttProjetoMetaHandler.ashx
+++ b/Portal/ApiHandler/GanttProjetoMetaHandler.ashx
@@ -49,9 +49,20 @@ public class GanttProjetoMetaHandler : IHttpHandler
     public void GetJsonProject(HttpContext context,int codEntidade,int idUsuario,int idCarteira)
     {
         var ganttDataset = UowApplication.GetUowApplication<CronogramaGanttProjetoMetaApplication>().GetGanttProjetoMetaDatasetDataTransfer(codEntidade, idUsuario, idCarteira, typeof(Resources.traducao));
+
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = new { rows = ganttDataset.tasks?.rows },
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable {

--- a/src/Cdis.Brisk.DataTransfer/Gantt/Balanceamento/TasksGanttBalanceamentoDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/Balanceamento/TasksGanttBalanceamentoDataTransfer.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Cdis.Brisk.DataTransfer.Gantt;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.Balanceamento
 {
-    public class TasksGanttBalanceamentoDataTransfer
+    public class TasksGanttBalanceamentoDataTransfer : TasksGanttDataTransfer
     {
-        public List<TaskItemGanttBalanceamentoDataTransfer> rows { get; set; }
+        public new List<TaskItemGanttBalanceamentoDataTransfer> rows { get; set; }
     }
 }
+

--- a/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/GanttDatasetDataTransfer.cs
@@ -4,7 +4,7 @@
     {
         public bool success { get; set; }
         public ProjectGanttDataTransfer project { get; set; }
-        public object tasks { get; set; }
+        public TasksGanttDataTransfer tasks { get; set; }
         public DependenciesGanttDataTransfer dependencies { get; set; }
         public ResourcesGanttDataTransfer resources { get; set; }
         public AssignmentsGanttDataTransfer assignments { get; set; }

--- a/src/Cdis.Brisk.DataTransfer/Gantt/PlanoAcao/TasksGanttPlanoAcaoDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/PlanoAcao/TasksGanttPlanoAcaoDataTransfer.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Cdis.Brisk.DataTransfer.Gantt;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.PlanoAcao
 {
-    public class TasksGanttPlanoAcaoDataTransfer
+    public class TasksGanttPlanoAcaoDataTransfer : TasksGanttDataTransfer
     {
-        public List<TaskItemGanttPlanoAcaoDataTransfer> rows { get; set; }
+        public new List<TaskItemGanttPlanoAcaoDataTransfer> rows { get; set; }
     }
 }
+

--- a/src/Cdis.Brisk.DataTransfer/Gantt/ProjetoMeta/TasksGanttProjetoMetaDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/ProjetoMeta/TasksGanttProjetoMetaDataTransfer.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Cdis.Brisk.DataTransfer.Gantt;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.ProjetoMeta
 {
-    public class TasksGanttProjetoMetaDataTransfer
+    public class TasksGanttProjetoMetaDataTransfer : TasksGanttDataTransfer
     {
-        public List<TaskItemGanttProjetoMetaDataTransfer> rows { get; set; }
+        public new List<TaskItemGanttProjetoMetaDataTransfer> rows { get; set; }
     }
 }
+


### PR DESCRIPTION
## Summary
- Wrap Gantt API responses to emit `tasks.rows` instead of `eventsData`
- Align balanceamento, plano de ação, and projeto meta handlers with Bryntum tree format

## Testing
- `dotnet build src/Cdis.Brisk.DataTransfer/Cdis.Brisk.DataTransfer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a077284df0833094e14f52426b0f5f