### PR TITLE
Ensure Gantt dataset uses tasks rows structure

### DIFF
--- a/Portal/ApiHandler/GanttBalanceamentoHandler.ashx
+++ b/Portal/ApiHandler/GanttBalanceamentoHandler.ashx
@@ -50,9 +50,20 @@ public class GanttBalanceamentoHandler : IHttpHandler
     public void GetJsonProject(HttpContext context,int codEntidade,int codPortfolio,int numCenario)
     {
         var ganttDataset = UowApplication.GetUowApplication<CronogramaGanttBalanceamentoApplication>().GetGanttDatasetDataTransfer(codEntidade, codPortfolio, numCenario, typeof(Resources.traducao));
+
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = ganttDataset.tasks,
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable {

--- a/Portal/ApiHandler/GanttHandler.ashx
+++ b/Portal/ApiHandler/GanttHandler.ashx
@@ -173,9 +173,19 @@ public class GanttHandler : IHttpHandler
         ganttDataset.resources = new ResourcesGanttDataTransfer { rows = recursos };
         ganttDataset.assignments = new AssignmentsGanttDataTransfer { rows = atribuicoes };
 
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = ganttDataset.tasks,
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable

--- a/Portal/ApiHandler/GanttPlanoAcaoHandler.ashx
+++ b/Portal/ApiHandler/GanttPlanoAcaoHandler.ashx
@@ -49,9 +49,19 @@ public class GanttPlanoAcaoHandler : IHttpHandler
                 ? UowApplication.GetUowApplication<CronogramaGanttPlanoAcaoApplication>().GetGanttDatasetDataTransfer(iniciaisObjeto, idObjeto, idEntidade, isIniciativas)
                 : UowApplication.GetUowApplication<CronogramaGanttPlanoAcaoApplication>().GetGanttPlanoAcaoDatasetDataTransfer(idPlanoAcao, iniciaisObjeto, idObjeto, idEntidade, isIniciativas);
 
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = ganttDataset.tasks,
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable {

--- a/Portal/ApiHandler/GanttProjetoMetaHandler.ashx
+++ b/Portal/ApiHandler/GanttProjetoMetaHandler.ashx
@@ -49,9 +49,20 @@ public class GanttProjetoMetaHandler : IHttpHandler
     public void GetJsonProject(HttpContext context,int codEntidade,int idUsuario,int idCarteira)
     {
         var ganttDataset = UowApplication.GetUowApplication<CronogramaGanttProjetoMetaApplication>().GetGanttProjetoMetaDatasetDataTransfer(codEntidade, idUsuario, idCarteira, typeof(Resources.traducao));
+
+        var payload = new
+        {
+            ganttDataset.success,
+            ganttDataset.project,
+            tasks = ganttDataset.tasks,
+            ganttDataset.dependencies,
+            ganttDataset.resources,
+            ganttDataset.assignments
+        };
+
         context.Response.ContentType = "application/json";
         context.Response.ContentEncoding = Encoding.UTF8;
-        context.Response.Write(ganttDataset.ToJson());
+        context.Response.Write(payload.ToJson());
     }
 
     public bool IsReusable {

--- a/src/Cdis.Brisk.Application/Applications/Cronograma/CronogramaGanttApplication.cs
+++ b/src/Cdis.Brisk.Application/Applications/Cronograma/CronogramaGanttApplication.cs
@@ -258,7 +258,7 @@ namespace Cdis.Brisk.Application.Applications.Cronograma
         /// <summary>
         /// Montar TaskGanttDataTransfer
         /// </summary>        
-        private TaskGanttDataTransfer MontarTaskGanttDataTransfer(FGetCronogramaGanttProjetoDomain task, List<FGetCronogramaGanttProjetoDomain> listTasks, Type typeResourceTraducao, bool isCarregarHtmlCaminhoCritico)
+        private TaskGanttDataTransfer MontarTaskGanttDataTransfer(FGetCronogramaGanttProjetoDomain task, List<FGetCronogramaGanttProjetoDomain> listTasks, Type typeResourceTraducao, bool isCarregarHtmlCaminhoCritico, int? parentId = null)
         {
             var listResourceTraducao = Cdis.Brisk.Infra.Core.Util.ResourceUtil.GetListResourceItem(typeResourceTraducao, new List<string> { "sim", "nao" });
             string langSim = listResourceTraducao.FirstOrDefault(t => t.Key == "sim").Text.ToUpper();
@@ -293,6 +293,7 @@ namespace Cdis.Brisk.Application.Applications.Cronograma
                 isAtrasoStr = (task.PercentualReal < task.PercentualPrevisto) ? langSim : langNao,
                 recurso = task.StringAlocacaoRecursoTarefa,
                 codTarefa = task.CodigoRealTarefa,
+                parentId = parentId,
                 custo = task.Custo,
                 children = GetListTaskGanttDataTransfer(task, listTasks, typeResourceTraducao, isCarregarHtmlCaminhoCritico)
             };
@@ -310,7 +311,7 @@ namespace Cdis.Brisk.Application.Applications.Cronograma
 
                 foreach (var taskItem in listTasks.Where(g => string.Equals(g.TarefaSuperior?.Trim(), codigo, StringComparison.OrdinalIgnoreCase)))
                 {
-                    listTaskGantt.Add((MontarTaskGanttDataTransfer(taskItem, listTasks, typeResourceTraducao, isCarregarHtmlCaminhoCritico)));
+                    listTaskGantt.Add(MontarTaskGanttDataTransfer(taskItem, listTasks, typeResourceTraducao, isCarregarHtmlCaminhoCritico, task.CodigoTarefa + 1));
                 }
 
                 return listTaskGantt;

--- a/src/Cdis.Brisk.DataTransfer/Gantt/Balanceamento/TasksGanttBalanceamentoDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/Balanceamento/TasksGanttBalanceamentoDataTransfer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.Balanceamento
 {

--- a/src/Cdis.Brisk.DataTransfer/Gantt/PlanoAcao/TasksGanttPlanoAcaoDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/PlanoAcao/TasksGanttPlanoAcaoDataTransfer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.PlanoAcao
 {

--- a/src/Cdis.Brisk.DataTransfer/Gantt/ProjetoMeta/TasksGanttProjetoMetaDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/ProjetoMeta/TasksGanttProjetoMetaDataTransfer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Cdis.Brisk.DataTransfer.Gantt.ProjetoMeta
 {

--- a/src/Cdis.Brisk.DataTransfer/Gantt/TaskGanttDataTransfer.cs
+++ b/src/Cdis.Brisk.DataTransfer/Gantt/TaskGanttDataTransfer.cs
@@ -33,6 +33,7 @@ namespace Cdis.Brisk.DataTransfer.Gantt
         public string isAtrasoStr { get; set; }
         public string recurso { get; set; }
         public string codTarefa { get; set; }
+        public int? parentId { get; set; }
         public bool expanded
         {
             get


### PR DESCRIPTION
## Summary
- Wrap Gantt API responses to emit `tasks.rows` instead of `eventsData`
- Align balanceamento, plano de ação, and projeto meta handlers with Bryntum tree format
- Restore generic `tasks` container so all payloads serialize correctly
- Propagate `parentId` for each task to preserve hierarchy in Bryntum

## Testing
- `dotnet build src/Cdis.Brisk.DataTransfer/Cdis.Brisk.DataTransfer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a077284df0833094e14f52426b0f5f