### PR TITLE
chore: hide calendar field from advanced tab

### DIFF
--- a/Portal/_Public/Gantt/paginas/detail/app.js
+++ b/Portal/_Public/Gantt/paginas/detail/app.js
@@ -128,6 +128,17 @@ const gantt = new Gantt({
         cellCopyPaste : true,
         taskCopyPaste : {
             useNativeClipboard : true
+        },
+        taskEdit : {
+            editorConfig : {
+                items : {
+                    advancedTab : {
+                        items : {
+                            calendarField : false
+                        }
+                    }
+                }
+            }
         }
     },
 

--- a/Portal/_Public/Gantt/paginas/detail/app.umd.js
+++ b/Portal/_Public/Gantt/paginas/detail/app.umd.js
@@ -98,7 +98,18 @@ const gantt = new Gantt({
         taskMenu: { disabled: false },
         filter: true,
         nonWorkingTime: { disabled: true },
-        percentBar: false
+        percentBar: false,
+        taskEdit: {
+            editorConfig: {
+                items: {
+                    advancedTab: {
+                        items: {
+                            calendarField: false
+                        }
+                    }
+                }
+            }
+        }
     },
 
     tbar: [


### PR DESCRIPTION
## Summary
- hide task calendar field in advanced tab of task editor

## Testing
- `npm test` (fails: Could not read package.json)
- `dotnet test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ab33398cb08330a244e18f7ba1e50e